### PR TITLE
Remove container_names preventing the use of multiple instances

### DIFF
--- a/1.5.0/docker-compose.yml
+++ b/1.5.0/docker-compose.yml
@@ -14,7 +14,6 @@ services:
 
   user-service:
     image: explorviz/explorviz-backend-user-service:1.5.0
-    container_name: explorviz-backend-user-service
     expose:
       - "8082"
     depends_on:
@@ -31,7 +30,6 @@ services:
 
   settings-service:
     image: explorviz/explorviz-backend-settings-service:1.5.0
-    container_name: explorviz-backend-settings-service
     expose:
       - "8087"
     depends_on:
@@ -48,11 +46,8 @@ services:
 
   landscape-service:
     image: explorviz/explorviz-backend-landscape-service:1.5.0
-    container_name: explorviz-backend-landscape-service
     ports:
       - "10135:10135"
-    expose:
-      - "10135"
     depends_on:
       - kafka
     environment:
@@ -61,7 +56,6 @@ services:
 
   broadcast-service:
     image: explorviz/explorviz-backend-broadcast-service:1.5.0
-    container_name: explorviz-backend-broadcast-service
     expose:
       - "8081"
     depends_on:
@@ -78,7 +72,6 @@ services:
 
   history-service:
     image: explorviz/explorviz-backend-history-service:1.5.0
-    container_name: explorviz-backend-history-service
     expose:
       - "8086"
     depends_on:
@@ -96,13 +89,11 @@ services:
 
   analysis-service:
     image: explorviz/explorviz-backend-analysis-service:1.5.0
-    container_name: explorviz-backend-analysis-service
     ports:
       - "10133:10133"
 
   discovery-service:
     image: explorviz/explorviz-backend-discovery-service:1.5.0
-    container_name: explorviz-backend-discovery-service
     ports:
       - "8083:8083"
     depends_on:
@@ -114,7 +105,6 @@ services:
 
   frontend:
     image: explorviz/explorviz-frontend:1.5.0
-    container_name: explorviz-frontend
     ports:
       - "8090:80"
     environment:
@@ -134,7 +124,6 @@ services:
 
   traefik:
     image: "traefik:v2.0.1"
-    container_name: "explorviz-reverse-proxy"
     command:
       - "--entrypoints.web.address=:8080"
       - "--providers.docker=true"
@@ -145,13 +134,11 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   zookeeper:
-    container_name: zookeeper
     image: wurstmeister/zookeeper
     expose:
       - "2181"
 
   kafka:
-    container_name: kafka
     image: wurstmeister/kafka
     depends_on:
       - zookeeper
@@ -161,10 +148,8 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
-
   mongo-user:
     image: mongo
-    container_name: explorviz-backend-user-mongo
     command: mongod --port 27017
     volumes:
        - explorviz-user-mongo-data:/data/db
@@ -174,7 +159,6 @@ services:
 
   mongo-history:
     image: mongo
-    container_name: explorviz-landscape-mongo
     command: mongod --port 27018
     volumes:
        - explorviz-landscape-mongo-data:/data/db
@@ -184,13 +168,12 @@ services:
 
   mongo-settings:
     image: mongo
-    container_name: explorviz-settings-mongo
     command: mongod --port 27019
-    ports:
-      - 27019:27019
     volumes:
       - explorviz-settings-mongo-data:/data/db
       - explorviz-settings-mongo-configdb:/data/configdb
+    expose:
+      - "27019"
 
 volumes:
   explorviz-user-mongo-data:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -14,7 +14,6 @@ services:
 
   user-service:
     image: explorviz/explorviz-backend-user-service:dev
-    container_name: explorviz-backend-user-service
     expose:
       - "8082"
     depends_on:
@@ -31,7 +30,6 @@ services:
 
   settings-service:
     image: explorviz/explorviz-backend-settings-service:dev
-    container_name: explorviz-backend-settings-service
     expose:
       - "8087"
     depends_on:
@@ -48,11 +46,8 @@ services:
 
   landscape-service:
     image: explorviz/explorviz-backend-landscape-service:dev
-    container_name: explorviz-backend-landscape-service
     ports:
       - "10135:10135"
-    expose:
-      - "10135"
     depends_on:
       - kafka
     environment:
@@ -61,7 +56,6 @@ services:
 
   broadcast-service:
     image: explorviz/explorviz-backend-broadcast-service:dev
-    container_name: explorviz-backend-broadcast-service
     expose:
       - "8081"
     depends_on:
@@ -78,7 +72,6 @@ services:
 
   history-service:
     image: explorviz/explorviz-backend-history-service:dev
-    container_name: explorviz-backend-history-service
     expose:
       - "8086"
     depends_on:
@@ -96,13 +89,11 @@ services:
 
   analysis-service:
     image: explorviz/explorviz-backend-analysis-service:dev
-    container_name: explorviz-backend-analysis-service
     ports:
       - "10133:10133"
 
   discovery-service:
     image: explorviz/explorviz-backend-discovery-service:dev
-    container_name: explorviz-backend-discovery-service
     ports:
       - "8083:8083"
     depends_on:
@@ -114,7 +105,6 @@ services:
 
   frontend:
     image: explorviz/explorviz-frontend:dev
-    container_name: explorviz-frontend
     ports:
       - "8090:80"
     environment:
@@ -133,8 +123,7 @@ services:
   ### Software Stack ###
 
   traefik:
-    image: "traefik:v2.0.1"
-    container_name: "explorviz-reverse-proxy"
+    image: "traefik:v2.1"
     command:
       - "--entrypoints.web.address=:8080"
       - "--providers.docker=true"
@@ -145,13 +134,11 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   zookeeper:
-    container_name: zookeeper
     image: wurstmeister/zookeeper
     expose:
       - "2181"
 
   kafka:
-    container_name: kafka
     image: wurstmeister/kafka
     depends_on:
       - zookeeper
@@ -161,10 +148,8 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
-
   mongo-user:
     image: mongo
-    container_name: explorviz-backend-user-mongo
     command: mongod --port 27017
     volumes:
        - explorviz-user-mongo-data:/data/db
@@ -174,7 +159,6 @@ services:
 
   mongo-history:
     image: mongo
-    container_name: explorviz-landscape-mongo
     command: mongod --port 27018
     volumes:
        - explorviz-landscape-mongo-data:/data/db
@@ -184,13 +168,12 @@ services:
 
   mongo-settings:
     image: mongo
-    container_name: explorviz-settings-mongo
     command: mongod --port 27019
-    ports:
-      - 27019:27019
     volumes:
       - explorviz-settings-mongo-data:/data/db
       - explorviz-settings-mongo-configdb:/data/configdb
+    expose:
+      - "27019"
 
 volumes:
   explorviz-user-mongo-data:


### PR DESCRIPTION
In EaaS we need to be able to start any amount of instances. This is achieved
by generating a unique docker-compose project name. Overwriting docker-composes
automatically generated container names means all containers from different
instances will have the same name and will therefore fail.

Also remove some superfluous expose options when ports are already published
using the ports options. One mongo instance had its port published.
This looked like a mistake, so change it to expose to only make it available
within the container network.

On dev update to the latest traefik version.